### PR TITLE
Add minimum React Application

### DIFF
--- a/src/manager.ts
+++ b/src/manager.ts
@@ -1,3 +1,0 @@
-console.log("Addon Onboarding");
-
-export {};

--- a/src/manager.tsx
+++ b/src/manager.tsx
@@ -1,0 +1,21 @@
+import ReactDOM from "react-dom";
+import React from "react";
+
+// Add a new DOM element to document.body, where we will bootstrap our React app
+const domNode = document.createElement("div");
+
+domNode.id = "addon-onboarding";
+domNode.style.position = "absolute";
+domNode.style.top = "0";
+domNode.style.left = "0";
+domNode.style.width = "0";
+domNode.style.height = "0";
+domNode.style.overflow = "hidden";
+domNode.style.opacity = "0";
+domNode.style.visibility = "hidden";
+
+// Append the new DOM element to document.body
+document.body.appendChild(domNode);
+
+// Render the React app
+ReactDOM.render(<div>Hello World</div>, domNode);

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig((options) => ({
-  entry: ["src/index.ts", "src/preview.ts", "src/manager.ts"],
+  entry: ["src/index.ts", "src/preview.ts", "src/manager.tsx"],
   splitting: false,
   minify: !options.watch,
   format: ["cjs", "esm"],


### PR DESCRIPTION
Closes https://github.com/storybookjs/addon-onboarding/issues/14

This PR bootstraps a dummy React application to the DOM. The element into which the React App gets bootstrapped is "invisible." Its containing HTML should not affect the manager's layout/appearance. The React application itself will use Modals/Tooltips in combination with React.Portal to show the components necessary for the onboarding flow. These components will use "React.Portal" to establish themselves in the `document.body`'s root.