### PR TITLE
Implement syntax highlighter

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,8 +74,8 @@
     "@storybook/blocks": "^7.0.0",
     "@storybook/components": "^7.0.0",
     "@storybook/core-events": "^7.0.0",
-    "@storybook/manager-api": "^7.0.0",
     "@storybook/jest": "^0.1.0",
+    "@storybook/manager-api": "^7.0.0",
     "@storybook/react": "^7.0.0",
     "@storybook/react-vite": "^7.0.0",
     "@storybook/testing-library": "^0.0.14-next.1",
@@ -129,6 +129,7 @@
   "homepage": "https://github.com/storybookjs/addon-onboarding#readme",
   "dependencies": {
     "@radix-ui/react-dialog": "^1.0.4",
+    "framer-motion": "^10.12.16",
     "react-confetti": "^6.1.0",
     "react-joyride": "^2.5.4"
   }

--- a/src/components/SyntaxHighlighter/Snippet/Snippet.styled.tsx
+++ b/src/components/SyntaxHighlighter/Snippet/Snippet.styled.tsx
@@ -1,0 +1,8 @@
+import { styled } from "@storybook/theming";
+import { motion } from "framer-motion";
+
+export const SnippetWrapper = styled(motion.div)<{ active?: boolean }>`
+  position: relative;
+  padding-top: 12px;
+  padding-bottom: 12px;
+`;

--- a/src/components/SyntaxHighlighter/Snippet/Snippet.tsx
+++ b/src/components/SyntaxHighlighter/Snippet/Snippet.tsx
@@ -1,0 +1,79 @@
+import { motion } from "framer-motion";
+import { forwardRef } from "react";
+import { SnippetWrapper } from "./Snippet.styled";
+import React from "react";
+import { SyntaxHighlighter as StorybookSyntaxHighlighter } from "@storybook/components";
+import { ThemeProvider, ensure, themes } from "@storybook/theming";
+
+interface Props {
+  contents: { content: string; toggle?: boolean }[];
+  active: boolean;
+  open?: boolean;
+}
+
+const wrapperVariants = {
+  default: {
+    filter: "grayscale(1)",
+    opacity: 0.5,
+  },
+  active: {
+    filter: "grayscale(0)",
+    opacity: 1,
+  },
+};
+
+export const Snippet = forwardRef<HTMLDivElement, Props>(
+  ({ active, contents, open }, ref) => {
+    return (
+      <ThemeProvider theme={ensure(themes.dark)}>
+        <SnippetWrapper
+          ref={ref}
+          initial="default"
+          animate={active ? "active" : "default"}
+          variants={wrapperVariants}
+          transition={{ ease: "easeInOut", duration: 0.6 }}
+        >
+          {contents.map(({ toggle, content }, i) => (
+            <>
+              {toggle === undefined && (
+                <StorybookSyntaxHighlighter
+                  key={i}
+                  language="javascript"
+                  customStyle={{ fontSize: "0.8rem" }}
+                >
+                  {content}
+                </StorybookSyntaxHighlighter>
+              )}
+
+              {toggle && !open && (
+                <StorybookSyntaxHighlighter
+                  key={i}
+                  language="javascript"
+                  customStyle={{ fontSize: "0.8rem" }}
+                >
+                  {`  ...`}
+                </StorybookSyntaxHighlighter>
+              )}
+
+              {toggle && open && (
+                <motion.div
+                  key={i}
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  transition={{ delay: 0.4 }}
+                >
+                  <StorybookSyntaxHighlighter
+                    language="javascript"
+                    customStyle={{ fontSize: "0.8rem" }}
+                  >
+                    {content}
+                  </StorybookSyntaxHighlighter>
+                </motion.div>
+              )}
+            </>
+          ))}
+        </SnippetWrapper>
+      </ThemeProvider>
+    );
+  }
+);

--- a/src/components/SyntaxHighlighter/Snippet/Snippet.tsx
+++ b/src/components/SyntaxHighlighter/Snippet/Snippet.tsx
@@ -30,6 +30,7 @@ export const Snippet = forwardRef<HTMLDivElement, Props>(
           ref={ref}
           initial="default"
           animate={active ? "active" : "default"}
+          aria-hidden={!active}
           variants={wrapperVariants}
           transition={{ ease: "easeInOut", duration: 0.6 }}
         >

--- a/src/components/SyntaxHighlighter/Snippet/Snippet.tsx
+++ b/src/components/SyntaxHighlighter/Snippet/Snippet.tsx
@@ -52,7 +52,7 @@ export const Snippet = forwardRef<HTMLDivElement, Props>(
                   language="javascript"
                   customStyle={{ fontSize: "0.8rem" }}
                 >
-                  {`  ...`}
+                  {`  // ...`}
                 </StorybookSyntaxHighlighter>
               )}
 

--- a/src/components/SyntaxHighlighter/Snippet/Snippet.tsx
+++ b/src/components/SyntaxHighlighter/Snippet/Snippet.tsx
@@ -66,6 +66,7 @@ export const Snippet = forwardRef<HTMLDivElement, Props>(
                   <StorybookSyntaxHighlighter
                     language="javascript"
                     customStyle={{ fontSize: "0.8rem" }}
+                    codeTagProps={{ style: { paddingLeft: "15px" } }}
                   >
                     {content}
                   </StorybookSyntaxHighlighter>

--- a/src/components/SyntaxHighlighter/SyntaxHighlighter.stories.tsx
+++ b/src/components/SyntaxHighlighter/SyntaxHighlighter.stories.tsx
@@ -1,6 +1,9 @@
 import { Meta, StoryObj } from "@storybook/react";
 import { SyntaxHighlighter } from "./SyntaxHighlighter";
 import React from "react";
+import { fireEvent, userEvent, within } from "@storybook/testing-library";
+import { expect } from "@storybook/jest";
+import { textContentMatcher } from "../../helpers/textContentMatcher";
 
 const meta: Meta<typeof SyntaxHighlighter> = {
   component: SyntaxHighlighter,
@@ -82,5 +85,44 @@ export const Default: Story = {
     contents: newData,
     activeStep: 1,
     width: "50%",
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const resetButton = canvas.getByText("Reset");
+    const previousButton = canvas.getByText("Previous");
+    const nextButton = canvas.getByText("Next");
+
+    const firstElement = await canvas.findByText(
+      textContentMatcher(newData[0][0].content)
+    );
+    const secondElement = await canvas.findByText(
+      textContentMatcher(newData[1][0].content)
+    );
+    const thirdElement = await canvas.findByText(
+      textContentMatcher(newData[2][0].content)
+    );
+
+    await expect(
+      firstElement.closest('[aria-hidden="true"]')
+    ).toBeInTheDocument();
+    await expect(
+      secondElement.closest('[aria-hidden="true"]')
+    ).not.toBeInTheDocument();
+    await expect(
+      thirdElement.closest('[aria-hidden="true"]')
+    ).toBeInTheDocument();
+
+    await userEvent.click(nextButton);
+
+    await expect(
+      firstElement.closest('[aria-hidden="true"]')
+    ).toBeInTheDocument();
+    await expect(
+      secondElement.closest('[aria-hidden="true"]')
+    ).toBeInTheDocument();
+    await expect(
+      thirdElement.closest('[aria-hidden="true"]')
+    ).not.toBeInTheDocument();
   },
 };

--- a/src/components/SyntaxHighlighter/SyntaxHighlighter.stories.tsx
+++ b/src/components/SyntaxHighlighter/SyntaxHighlighter.stories.tsx
@@ -1,0 +1,86 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { SyntaxHighlighter } from "./SyntaxHighlighter";
+import React from "react";
+
+const meta: Meta<typeof SyntaxHighlighter> = {
+  component: SyntaxHighlighter,
+  parameters: {
+    chromatic: { delay: 300 },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof SyntaxHighlighter>;
+
+const newData = [
+  [
+    {
+      content: `// Button.stories.tsx`,
+    },
+  ],
+  [
+    {
+      content: `import type { Meta, StoryObj } from '@storybook/react';
+
+import { Button } from './Button';`,
+    },
+  ],
+  [
+    {
+      content: `const meta: Meta<typeof Button> = {
+  title: 'Example/Button',
+  component: Button,
+  ...
+};
+    
+export default meta;`,
+    },
+  ],
+  [
+    { content: `export const Primary: Story = {` },
+    {
+      content: `  args: {
+    primary: true,
+    label: 'Click',
+    background: 'red',
+  },`,
+      toggle: true,
+    },
+    { content: `};` },
+  ],
+  [
+    {
+      content: `// Copy the code below
+
+  export const Warning: Story = {
+    args: {
+      backgroundColor: 'red',
+      label: 'Delete now',
+    },
+  };`,
+    },
+  ],
+];
+
+export const Default: Story = {
+  render: (args) => {
+    const [activeStep, setActiveStep] = React.useState(1);
+
+    return (
+      <div>
+        <SyntaxHighlighter {...args} activeStep={activeStep} />
+        <button onClick={() => setActiveStep(0)}>Reset</button>
+        <button onClick={() => setActiveStep((step) => step - 1)}>
+          Previous
+        </button>
+        <button onClick={() => setActiveStep((step) => step + 1)}>Next</button>
+      </div>
+    );
+  },
+  args: {
+    contents: newData,
+    activeStep: 1,
+    width: "50%",
+  },
+};

--- a/src/components/SyntaxHighlighter/SyntaxHighlighter.stories.tsx
+++ b/src/components/SyntaxHighlighter/SyntaxHighlighter.stories.tsx
@@ -34,7 +34,7 @@ import { Button } from './Button';`,
       content: `const meta: Meta<typeof Button> = {
   title: 'Example/Button',
   component: Button,
-  ...
+  // ...
 };
     
 export default meta;`,
@@ -43,11 +43,11 @@ export default meta;`,
   [
     { content: `export const Primary: Story = {` },
     {
-      content: `  args: {
+      content: `args: {
     primary: true,
     label: 'Click',
-    background: 'red',
-  },`,
+    background: 'red'
+  }`,
       toggle: true,
     },
     { content: `};` },
@@ -59,8 +59,8 @@ export default meta;`,
   export const Warning: Story = {
     args: {
       backgroundColor: 'red',
-      label: 'Delete now',
-    },
+      label: 'Delete now'
+    }
   };`,
     },
   ],
@@ -89,8 +89,6 @@ export const Default: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    const resetButton = canvas.getByText("Reset");
-    const previousButton = canvas.getByText("Previous");
     const nextButton = canvas.getByText("Next");
 
     const firstElement = await canvas.findByText(

--- a/src/components/SyntaxHighlighter/SyntaxHighlighter.styled.tsx
+++ b/src/components/SyntaxHighlighter/SyntaxHighlighter.styled.tsx
@@ -1,0 +1,36 @@
+import { styled } from "@storybook/theming";
+import { motion } from "framer-motion";
+
+export const Code = styled(motion.div)`
+  position: relative;
+  z-index: 2;
+`;
+
+export const Container = styled.div<{ width: string }>`
+  position: relative;
+  box-sizing: border-box;
+  background: #171c23;
+  width: ${({ width }) => width};
+  height: 100%;
+  overflow: hidden;
+  padding-left: 15px;
+  padding-right: 15px;
+  padding-top: 6px;
+
+  && {
+    pre {
+      background: transparent !important;
+      margin: 0 !important;
+      padding: 0 !important;
+    }
+  }
+`;
+
+export const Backdrop = styled(motion.div)`
+  background: #143046;
+  position: absolute;
+  z-index: 1;
+  left: 0;
+  width: 100%;
+  height: 200px;
+`;

--- a/src/components/SyntaxHighlighter/SyntaxHighlighter.tsx
+++ b/src/components/SyntaxHighlighter/SyntaxHighlighter.tsx
@@ -1,0 +1,106 @@
+import React, { useCallback, useEffect, useLayoutEffect, useMemo } from "react";
+import { Backdrop, Code, Container } from "./SyntaxHighlighter.styled";
+import { Snippet } from "./Snippet/Snippet";
+
+type SyntaxHighlighterProps = {
+  contents: { content: string; toggle?: boolean }[][];
+  activeStep: number;
+  width: string;
+};
+
+const OFFSET = 49;
+
+export const SyntaxHighlighter = ({
+  activeStep,
+  contents,
+  width,
+}: SyntaxHighlighterProps) => {
+  const [steps, setSteps] = React.useState<
+    { yPos: number; height: number; index: number; open: boolean }[]
+  >([]);
+
+  const refs = useMemo(
+    () => contents.map(() => React.createRef<HTMLDivElement>()),
+    [contents]
+  );
+
+  const getYPos = (idx: number) => {
+    let yPos = 0;
+    for (let i = 0; i < idx; i++) {
+      yPos -= refs[i].current!.getBoundingClientRect().height;
+    }
+    return yPos;
+  };
+
+  const setNewSteps = useCallback(() => {
+    const newSteps = contents.flatMap((content, i) => {
+      const height = refs[i].current!.getBoundingClientRect().height;
+      const finalSteps = [
+        {
+          yPos: getYPos(i) + OFFSET - 7,
+          height,
+          index: i,
+          open: false,
+        },
+      ];
+
+      if (content.length > 1) {
+        finalSteps.push({
+          yPos: getYPos(i) + OFFSET - 7,
+          height,
+          index: i,
+          open: true,
+        });
+      }
+
+      return finalSteps;
+    });
+
+    setSteps(newSteps);
+  }, [contents]);
+
+  useEffect(() => {
+    // Call setNewSteps every time height of the refs elements changes
+    const resizeObserver = new ResizeObserver(() => {
+      setNewSteps();
+    });
+
+    refs.forEach((ref) => {
+      resizeObserver.observe(ref.current!);
+    });
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, []);
+
+  return (
+    <>
+      <Container width={width}>
+        <Code
+          animate={{ y: steps[activeStep]?.yPos ?? 0 }}
+          transition={{ ease: "easeInOut", duration: 0.6 }}
+        >
+          {contents.map((content, idx: number) => (
+            <Snippet
+              key={idx}
+              ref={refs[idx]}
+              active={steps[activeStep]?.index === idx}
+              open={
+                steps[activeStep]?.index > idx
+                  ? true
+                  : steps[activeStep]?.open ?? false
+              }
+              contents={content}
+            />
+          ))}
+        </Code>
+        <Backdrop
+          animate={{ height: steps[activeStep]?.height ?? 0 }}
+          transition={{ ease: "easeInOut", duration: 0.6 }}
+          style={{ top: OFFSET }}
+        />
+      </Container>
+    </>
+  );
+};

--- a/src/helpers/textContentMatcher.tsx
+++ b/src/helpers/textContentMatcher.tsx
@@ -1,0 +1,30 @@
+/**
+ * Getting the deepest element that contain string / match regex even when it split between multiple elements
+ *
+ * @example
+ * For:
+ * <div>
+ *   <span>Hello</span><span> World</span>
+ * </div>
+ *
+ * screen.getByText('Hello World') // ❌ Fail
+ * screen.getByText(textContentMatcher('Hello World')) // ✅ pass
+ */
+export function textContentMatcher(textMatch: string | RegExp) {
+  const hasText =
+    typeof textMatch === "string"
+      ? (node: Element) => node.textContent === textMatch
+      : (node: Element) => textMatch.test(node.textContent);
+
+  const matcher = (_content: string, node: Element) => {
+    if (!hasText(node)) {
+      return false;
+    }
+
+    return Array.from(node?.children || []).every((child) => !hasText(child));
+  };
+
+  matcher.toString = () => `textContentMatcher(${textMatch})`;
+
+  return matcher;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1466,6 +1466,18 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
+"@emotion/is-prop-valid@^0.8.2":
+  version "0.8.8"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"
+  integrity sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==
+  dependencies:
+    "@emotion/memoize" "0.7.4"
+
+"@emotion/memoize@0.7.4":
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.4.tgz#19bf0f5af19149111c40d98bb0cf82119f5d9eeb"
+  integrity sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==
+
 "@emotion/use-insertion-effect-with-fallbacks@^1.0.0":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.1.tgz#08de79f54eb3406f9daaf77c76e35313da963963"
@@ -5143,6 +5155,15 @@ fp-ts@^2.5.3:
   version "2.16.0"
   resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-2.16.0.tgz#64e03314dfc1c7ce5e975d3496ac14bc3eb7f92e"
   integrity sha512-bLq+KgbiXdTEoT1zcARrWEpa5z6A/8b7PcDW7Gef3NSisQ+VS7ll2Xbf1E+xsgik0rWub/8u0qP/iTTjj+PhxQ==
+
+framer-motion@^10.12.16:
+  version "10.12.16"
+  resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-10.12.16.tgz#ccba11d216ac370c6bc65fcd9953a61deb54f071"
+  integrity sha512-w/SfWEIWJkYSgRHYBmln7EhcNo31ao8Xexol8lGXf1pR/tlnBtf1HcxoUmEiEh6pacB4/geku5ami53AAQWHMQ==
+  dependencies:
+    tslib "^2.4.0"
+  optionalDependencies:
+    "@emotion/is-prop-valid" "^0.8.2"
 
 fresh@0.5.2:
   version "0.5.2"


### PR DESCRIPTION
Closes https://github.com/storybookjs/addon-onboarding/issues/9

## What I did

I have implemented a generic syntax highlighter, which can be used in the "How to write your first Story" flow.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.13--canary.20.b5f373d.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/addon-onboarding@0.0.13--canary.20.b5f373d.0
  # or 
  yarn add @storybook/addon-onboarding@0.0.13--canary.20.b5f373d.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
