### PR TITLE
Trigger via `/onboarding` path instead of query parameter

### DIFF
--- a/src/manager.tsx
+++ b/src/manager.tsx
@@ -8,7 +8,7 @@ const App = lazy(() => import("./App"));
 // 1. The onboarding query parameter is present
 // 2. The example button stories are present
 addons.register("@storybook/addon-onboarding", async (api) => {
-  const isOnboarding = api.getUrlState().queryParams.onboarding;
+  const isOnboarding = api.getUrlState().path === '/onboarding';
 
   if (!isOnboarding) {
     return;


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.14--canary.21.648a737.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/addon-onboarding@0.0.14--canary.21.648a737.0
  # or 
  yarn add @storybook/addon-onboarding@0.0.14--canary.21.648a737.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
