### PR TITLE
Modal improvements

### DIFF
--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -30,7 +30,7 @@ export const Default: Story = {
         <Modal {...props} open={isOpen}>
           {({ Close }) => (
             <>
-              <div>Hello world</div>
+              <div>Hello world!</div>
               <Close onClick={() => setOpen(false)}>Close</Close>
             </>
           )}
@@ -43,7 +43,9 @@ export const Default: Story = {
     const canvas = within(canvasElement.parentElement);
     const button = canvas.getByText("Open modal");
     await userEvent.click(button);
-    await expect(canvas.findByText("Hello world")).resolves.toBeInTheDocument();
+    await expect(
+      canvas.findByText("Hello world!")
+    ).resolves.toBeInTheDocument();
   },
 };
 
@@ -59,7 +61,7 @@ export const FixedWidth: Story = {
         <Modal {...props} open={isOpen}>
           {({ Close }) => (
             <>
-              <div>Hello world</div>
+              <div>Hello world!</div>
               <Close onClick={() => setOpen(false)}>Close</Close>
             </>
           )}
@@ -72,7 +74,9 @@ export const FixedWidth: Story = {
     const canvas = within(canvasElement.parentElement);
     const button = canvas.getByText("Open modal");
     await userEvent.click(button);
-    await expect(canvas.findByText("Hello world")).resolves.toBeInTheDocument();
+    await expect(
+      canvas.findByText("Hello world!")
+    ).resolves.toBeInTheDocument();
   },
 };
 
@@ -88,7 +92,7 @@ export const FixedHeight: Story = {
         <Modal {...props} open={isOpen}>
           {({ Close }) => (
             <>
-              <div>Hello world</div>
+              <div>Hello world!</div>
               <Close onClick={() => setOpen(false)}>Close</Close>
             </>
           )}
@@ -101,7 +105,9 @@ export const FixedHeight: Story = {
     const canvas = within(canvasElement.parentElement);
     const button = canvas.getByText("Open modal");
     await userEvent.click(button);
-    await expect(canvas.findByText("Hello world")).resolves.toBeInTheDocument();
+    await expect(
+      canvas.findByText("Hello world!")
+    ).resolves.toBeInTheDocument();
   },
 };
 
@@ -118,7 +124,7 @@ export const FixedWidthAndHeight: Story = {
         <Modal {...props} open={isOpen}>
           {({ Close }) => (
             <>
-              <div>Hello world</div>
+              <div>Hello world!</div>
               <Close onClick={() => setOpen(false)}>Close</Close>
             </>
           )}
@@ -131,6 +137,8 @@ export const FixedWidthAndHeight: Story = {
     const canvas = within(canvasElement.parentElement);
     const button = canvas.getByText("Open modal");
     await userEvent.click(button);
-    await expect(canvas.findByText("Hello world")).resolves.toBeInTheDocument();
+    await expect(
+      canvas.findByText("Hello world!")
+    ).resolves.toBeInTheDocument();
   },
 };

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -19,16 +19,18 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  render: () => {
+  args: {
+    width: undefined,
+    height: undefined,
+  },
+  render: (props) => {
     const [isOpen, setOpen] = useState(false);
     return (
       <>
-        <Modal open={isOpen}>
-          {({ Title, Description, Close }) => (
+        <Modal {...props} open={isOpen}>
+          {({ Close }) => (
             <>
-              Hello world
-              <Title>Modal Title</Title>
-              <Description>Modal Description</Description>
+              <div>Hello world</div>
               <Close onClick={() => setOpen(false)}>Close</Close>
             </>
           )}
@@ -46,16 +48,77 @@ export const Default: Story = {
 };
 
 export const FixedWidth: Story = {
-  render: () => {
+  args: {
+    ...Default.args,
+    width: 1024,
+  },
+  render: (props) => {
     const [isOpen, setOpen] = useState(false);
     return (
       <>
-        <Modal width="740px" open={isOpen}>
-          {({ Title, Description, Close }) => (
+        <Modal {...props} open={isOpen}>
+          {({ Close }) => (
             <>
-              Hello world
-              <Title>Modal Title</Title>
-              <Description>Modal Description</Description>
+              <div>Hello world</div>
+              <Close onClick={() => setOpen(false)}>Close</Close>
+            </>
+          )}
+        </Modal>
+        <button onClick={() => setOpen(true)}>Open modal</button>
+      </>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement.parentElement);
+    const button = canvas.getByText("Open modal");
+    await userEvent.click(button);
+    await expect(canvas.findByText("Hello world")).resolves.toBeInTheDocument();
+  },
+};
+
+export const FixedHeight: Story = {
+  args: {
+    ...Default.args,
+    height: 430,
+  },
+  render: (props) => {
+    const [isOpen, setOpen] = useState(false);
+    return (
+      <>
+        <Modal {...props} open={isOpen}>
+          {({ Close }) => (
+            <>
+              <div>Hello world</div>
+              <Close onClick={() => setOpen(false)}>Close</Close>
+            </>
+          )}
+        </Modal>
+        <button onClick={() => setOpen(true)}>Open modal</button>
+      </>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement.parentElement);
+    const button = canvas.getByText("Open modal");
+    await userEvent.click(button);
+    await expect(canvas.findByText("Hello world")).resolves.toBeInTheDocument();
+  },
+};
+
+export const FixedWidthAndHeight: Story = {
+  args: {
+    ...Default.args,
+    width: 1024,
+    height: 430,
+  },
+  render: (props) => {
+    const [isOpen, setOpen] = useState(false);
+    return (
+      <>
+        <Modal {...props} open={isOpen}>
+          {({ Close }) => (
+            <>
+              <div>Hello world</div>
               <Close onClick={() => setOpen(false)}>Close</Close>
             </>
           )}

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -23,6 +23,33 @@ export const Default: Story = {
     const [isOpen, setOpen] = useState(false);
     return (
       <>
+        <Modal open={isOpen}>
+          {({ Title, Description, Close }) => (
+            <>
+              Hello world
+              <Title>Modal Title</Title>
+              <Description>Modal Description</Description>
+              <Close onClick={() => setOpen(false)}>Close</Close>
+            </>
+          )}
+        </Modal>
+        <button onClick={() => setOpen(true)}>Open modal</button>
+      </>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement.parentElement);
+    const button = canvas.getByText("Open modal");
+    await userEvent.click(button);
+    await expect(canvas.findByText("Hello world")).resolves.toBeInTheDocument();
+  },
+};
+
+export const FixedWidth: Story = {
+  render: () => {
+    const [isOpen, setOpen] = useState(false);
+    return (
+      <>
         <Modal width="740px" open={isOpen}>
           {({ Title, Description, Close }) => (
             <>

--- a/src/components/Modal/Modal.styled.tsx
+++ b/src/components/Modal/Modal.styled.tsx
@@ -10,8 +10,8 @@ export const StyledOverlay = styled(Dialog.Overlay)`
   height: 100%;
 `;
 
-export const StyledContent = styled.div<{ width: string }>(
-  ({ width }) => css`
+export const StyledContent = styled.div<{ width: number; height: number }>(
+  ({ width, height }) => css`
     background-color: white;
     border-radius: 6px;
     box-shadow: rgba(14, 18, 22, 0.35) 0px 10px 38px -10px;
@@ -19,7 +19,8 @@ export const StyledContent = styled.div<{ width: string }>(
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    width: ${width ?? "calc(100% - 40px)"};
+    width: ${width ?? 740}px;
+    height: ${height ? `${height}px` : "auto"};
     max-width: calc(100% - 40px);
     max-height: 85vh;
   `
@@ -29,8 +30,10 @@ export const ContentWrapper = React.forwardRef<
   HTMLDivElement,
   React.ComponentProps<typeof StyledContent> &
     React.ComponentProps<typeof Dialog.Content>
->(({ width, children, ...contentProps }, ref) => (
+>(({ width, height, children, ...contentProps }, ref) => (
   <Dialog.Content ref={ref} asChild {...contentProps}>
-    <StyledContent width={width}>{children}</StyledContent>
+    <StyledContent width={width} height={height}>
+      {children}
+    </StyledContent>
   </Dialog.Content>
 ));

--- a/src/components/Modal/Modal.styled.tsx
+++ b/src/components/Modal/Modal.styled.tsx
@@ -1,20 +1,14 @@
 import { css, styled } from "@storybook/theming";
-import {
-  Overlay,
-  Content,
-  Title,
-  Description,
-  Close,
-} from "@radix-ui/react-dialog";
+import * as Dialog from "@radix-ui/react-dialog";
 import React from "react";
 
-export const StyledOverlay = styled(Overlay)`
-  background-color: rgba(0, 0, 0, 0.25);
+export const StyledOverlay = styled(Dialog.Overlay)`
+  background-color: rgba(27, 28, 29, 0.48);
   position: fixed;
   inset: 0px;
   width: 100%;
   height: 100%;
-})`;
+`;
 
 export const StyledContent = styled.div<{ width: string }>(
   ({ width }) => css`
@@ -34,24 +28,9 @@ export const StyledContent = styled.div<{ width: string }>(
 export const ContentWrapper = React.forwardRef<
   HTMLDivElement,
   React.ComponentProps<typeof StyledContent> &
-    React.ComponentProps<typeof Content>
+    React.ComponentProps<typeof Dialog.Content>
 >(({ width, children, ...contentProps }, ref) => (
-  <Content ref={ref} asChild {...contentProps}>
+  <Dialog.Content ref={ref} asChild {...contentProps}>
     <StyledContent width={width}>{children}</StyledContent>
-  </Content>
+  </Dialog.Content>
 ));
-
-export const StyledTitle = styled(Title)`
-  color: #000;
-  font-weight: 700;
-  font-size: 20px;
-  line-height: 20px;
-`;
-export const StyledDescription = styled(Description)`
-  font-size: 14px;
-  font-weight: 400;
-  line-height: 20px;
-  color: #454e54;
-`;
-
-export const StyledClose = styled(Close)``;

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,13 +1,6 @@
 import React from "react";
-
 import * as Dialog from "@radix-ui/react-dialog";
-import {
-  ContentWrapper,
-  StyledClose,
-  StyledDescription,
-  StyledOverlay,
-  StyledTitle,
-} from "./Modal.styled";
+import { ContentWrapper, StyledOverlay } from "./Modal.styled";
 
 type ContentProps = React.ComponentProps<typeof ContentWrapper>;
 
@@ -15,9 +8,9 @@ interface ModalProps
   extends Omit<React.ComponentProps<typeof Dialog.Root>, "children"> {
   width?: string;
   children: (props: {
-    Title: typeof StyledTitle;
-    Description: typeof StyledDescription;
-    Close: typeof StyledClose;
+    Title: typeof Dialog.Title;
+    Description: typeof Dialog.Description;
+    Close: typeof Dialog.Close;
   }) => React.ReactNode;
   onEscapeKeyDown?: ContentProps["onEscapeKeyDown"];
   onInteractOutside?: ContentProps["onInteractOutside"];
@@ -40,9 +33,9 @@ export function Modal({
           onEscapeKeyDown={onEscapeKeyDown}
         >
           {children({
-            Title: StyledTitle,
-            Description: StyledDescription,
-            Close: StyledClose,
+            Title: Dialog.Title,
+            Description: Dialog.Description,
+            Close: Dialog.Close,
           })}
         </ContentWrapper>
       </Dialog.Portal>

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -6,7 +6,8 @@ type ContentProps = React.ComponentProps<typeof ContentWrapper>;
 
 interface ModalProps
   extends Omit<React.ComponentProps<typeof Dialog.Root>, "children"> {
-  width?: string;
+  width?: number;
+  height?: number;
   children: (props: {
     Title: typeof Dialog.Title;
     Description: typeof Dialog.Description;
@@ -19,6 +20,7 @@ interface ModalProps
 export function Modal({
   children,
   width,
+  height,
   onEscapeKeyDown,
   onInteractOutside = (ev) => ev.preventDefault(),
   ...rootProps
@@ -29,6 +31,7 @@ export function Modal({
         <StyledOverlay />
         <ContentWrapper
           width={width}
+          height={height}
           onInteractOutside={onInteractOutside}
           onEscapeKeyDown={onEscapeKeyDown}
         >

--- a/src/features/WelcomeModal/WelcomeModal.styled.tsx
+++ b/src/features/WelcomeModal/WelcomeModal.styled.tsx
@@ -1,6 +1,21 @@
 import { Icons } from "@storybook/components";
 import { keyframes, styled } from "@storybook/theming";
 
+export const Title = styled.h1`
+  color: #2e3438;
+  font-weight: 700;
+  font-size: 20px;
+  line-height: 20px;
+`;
+
+export const Description = styled.p`
+  text-align: center;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 20px;
+  color: #454e54;
+`;
+
 export const rainbowAnimation = keyframes`
   0% {
     background-position: 0% 50%;

--- a/src/features/WelcomeModal/WelcomeModal.tsx
+++ b/src/features/WelcomeModal/WelcomeModal.tsx
@@ -7,6 +7,8 @@ import {
   ModalContentWrapper,
   SkipButton,
   StyledIcon,
+  Title,
+  Description,
 } from "./WelcomeModal.styled";
 
 export const WelcomeModal = ({
@@ -18,7 +20,7 @@ export const WelcomeModal = ({
 }) => {
   return (
     <Modal width="540px" defaultOpen>
-      {({ Title, Description, Close }) => (
+      {({ Close }) => (
         <ModalContentWrapper data-chromatic="ignore">
           <StorybookLogo />
           <Title style={{ marginTop: 20 }}>Welcome to Storybook</Title>

--- a/src/features/WelcomeModal/WelcomeModal.tsx
+++ b/src/features/WelcomeModal/WelcomeModal.tsx
@@ -19,7 +19,7 @@ export const WelcomeModal = ({
   onProceed: () => void;
 }) => {
   return (
-    <Modal width="540px" defaultOpen>
+    <Modal width={540} defaultOpen>
       {({ Close }) => (
         <ModalContentWrapper data-chromatic="ignore">
           <StorybookLogo />

--- a/src/features/WriteStoriesModal/WriteStoriesModal.tsx
+++ b/src/features/WriteStoriesModal/WriteStoriesModal.tsx
@@ -7,7 +7,7 @@ import { ModalContentWrapper } from "../WelcomeModal/WelcomeModal.styled";
 
 export function WriteStoriesModal({ onFinish }: { onFinish: () => void }) {
   return (
-    <Modal width="540px" defaultOpen>
+    <Modal width={540} defaultOpen>
       {({ Title, Description }) => (
         <ModalContentWrapper data-chromatic="ignore">
           <StorybookLogo />


### PR DESCRIPTION
Closes https://github.com/storybookjs/addon-onboarding/issues/23

In this PR I'm focusing on improving elements for the Modal component only including:
- Add a height property to fix the height of the modal the same way we do for width.
- Add a default width to make sure it never goes full screen on desktop.
- Added missing stories and controls.
- Removed styling and props for Title and Description. I don't believe we need those for this component.
- Move the styling of the Title + Description to the WelcomeModal
- Unified how we call Radix across the component and styles


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.14--canary.22.27381c8.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/addon-onboarding@0.0.14--canary.22.27381c8.0
  # or 
  yarn add @storybook/addon-onboarding@0.0.14--canary.22.27381c8.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
