### PR TITLE
use onboarding parameter in conjunction with onboarding path

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,6 +48,7 @@ export default function App({ api }: { api: API }) {
 
   useEffect(() => {
     api.once(CURRENT_STORY_WAS_SET, ({ storyId }) => {
+      api.setQueryParams({ onboarding: "true" });
       // make sure the initial state is set correctly:
       // 1. Selected story is primary button
       // 2. The addon panel is opened, in the bottom and the controls tab is selected

--- a/src/manager.tsx
+++ b/src/manager.tsx
@@ -8,7 +8,8 @@ const App = lazy(() => import("./App"));
 // 1. The onboarding query parameter is present
 // 2. The example button stories are present
 addons.register("@storybook/addon-onboarding", async (api) => {
-  const isOnboarding = api.getUrlState().path === '/onboarding';
+  const urlState = api.getUrlState();
+  const isOnboarding = urlState.path === '/onboarding' || urlState.queryParams.onboarding === 'true';
 
   if (!isOnboarding) {
     return;


### PR DESCRIPTION
Given that the onboarding flow will be triggered via Storybook through the `path=/onboarding` parameter, it will get lost once the story is redirected. This PR makes it so that the addon sets `?onboarding=true` and removes it once finished, so that users that, for some reason refresh the browser, still get back to the onboarding flow rather than lose it "forever".