### PR TITLE
Improve write a story modal

### DIFF
--- a/src/components/SyntaxHighlighter/Snippet/Snippet.tsx
+++ b/src/components/SyntaxHighlighter/Snippet/Snippet.tsx
@@ -24,6 +24,11 @@ const wrapperVariants = {
 
 export const Snippet = forwardRef<HTMLDivElement, Props>(
   ({ active, content, open }, ref) => {
+    const customStyle = {
+      fontSize: "0.8125rem",
+      lineHeight: "1.1875rem",
+    };
+
     return (
       <ThemeProvider theme={ensure(themes.dark)}>
         <SnippetWrapper
@@ -39,7 +44,7 @@ export const Snippet = forwardRef<HTMLDivElement, Props>(
               {toggle === undefined && (
                 <StorybookSyntaxHighlighter
                   language="javascript"
-                  customStyle={{ fontSize: "0.8125rem" }}
+                  customStyle={customStyle}
                 >
                   {code}
                 </StorybookSyntaxHighlighter>
@@ -48,7 +53,7 @@ export const Snippet = forwardRef<HTMLDivElement, Props>(
               {toggle && !open && (
                 <StorybookSyntaxHighlighter
                   language="javascript"
-                  customStyle={{ fontSize: "0.8125rem" }}
+                  customStyle={customStyle}
                 >
                   {`  // ...`}
                 </StorybookSyntaxHighlighter>
@@ -62,7 +67,7 @@ export const Snippet = forwardRef<HTMLDivElement, Props>(
                 >
                   <StorybookSyntaxHighlighter
                     language="javascript"
-                    customStyle={{ fontSize: "0.8125rem" }}
+                    customStyle={customStyle}
                     codeTagProps={{ style: { paddingLeft: "15px" } }}
                   >
                     {code}

--- a/src/components/SyntaxHighlighter/Snippet/Snippet.tsx
+++ b/src/components/SyntaxHighlighter/Snippet/Snippet.tsx
@@ -6,7 +6,7 @@ import { SyntaxHighlighter as StorybookSyntaxHighlighter } from "@storybook/comp
 import { ThemeProvider, ensure, themes } from "@storybook/theming";
 
 interface Props {
-  contents: { content: string; toggle?: boolean }[];
+  content: { code: string; toggle?: boolean }[];
   active: boolean;
   open?: boolean;
 }
@@ -23,7 +23,7 @@ const wrapperVariants = {
 };
 
 export const Snippet = forwardRef<HTMLDivElement, Props>(
-  ({ active, contents, open }, ref) => {
+  ({ active, content, open }, ref) => {
     return (
       <ThemeProvider theme={ensure(themes.dark)}>
         <SnippetWrapper
@@ -34,21 +34,21 @@ export const Snippet = forwardRef<HTMLDivElement, Props>(
           variants={wrapperVariants}
           transition={{ ease: "easeInOut", duration: 0.6 }}
         >
-          {contents.map(({ toggle, content }, i) => (
+          {content.map(({ toggle, code }, i) => (
             <Fragment key={i}>
               {toggle === undefined && (
                 <StorybookSyntaxHighlighter
                   language="javascript"
-                  customStyle={{ fontSize: "0.8rem" }}
+                  customStyle={{ fontSize: "0.8125rem" }}
                 >
-                  {content}
+                  {code}
                 </StorybookSyntaxHighlighter>
               )}
 
               {toggle && !open && (
                 <StorybookSyntaxHighlighter
                   language="javascript"
-                  customStyle={{ fontSize: "0.8rem" }}
+                  customStyle={{ fontSize: "0.8125rem" }}
                 >
                   {`  // ...`}
                 </StorybookSyntaxHighlighter>
@@ -62,10 +62,10 @@ export const Snippet = forwardRef<HTMLDivElement, Props>(
                 >
                   <StorybookSyntaxHighlighter
                     language="javascript"
-                    customStyle={{ fontSize: "0.8rem" }}
+                    customStyle={{ fontSize: "0.8125rem" }}
                     codeTagProps={{ style: { paddingLeft: "15px" } }}
                   >
-                    {content}
+                    {code}
                   </StorybookSyntaxHighlighter>
                 </motion.div>
               )}

--- a/src/components/SyntaxHighlighter/SyntaxHighlighter.stories.tsx
+++ b/src/components/SyntaxHighlighter/SyntaxHighlighter.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta, StoryObj } from "@storybook/react";
 import { SyntaxHighlighter } from "./SyntaxHighlighter";
 import React from "react";
-import { fireEvent, userEvent, within } from "@storybook/testing-library";
+import { userEvent, within } from "@storybook/testing-library";
 import { expect } from "@storybook/jest";
 import { textContentMatcher } from "../../helpers/textContentMatcher";
 
@@ -19,19 +19,19 @@ type Story = StoryObj<typeof SyntaxHighlighter>;
 const newData = [
   [
     {
-      content: `// Button.stories.tsx`,
+      code: `// Button.stories.tsx`,
     },
   ],
   [
     {
-      content: `import type { Meta, StoryObj } from '@storybook/react';
+      code: `import type { Meta, StoryObj } from '@storybook/react';
 
 import { Button } from './Button';`,
     },
   ],
   [
     {
-      content: `const meta: Meta<typeof Button> = {
+      code: `const meta: Meta<typeof Button> = {
   title: 'Example/Button',
   component: Button,
   // ...
@@ -41,20 +41,20 @@ export default meta;`,
     },
   ],
   [
-    { content: `export const Primary: Story = {` },
+    { code: `export const Primary: Story = {` },
     {
-      content: `args: {
+      code: `args: {
     primary: true,
     label: 'Click',
     background: 'red'
   }`,
       toggle: true,
     },
-    { content: `};` },
+    { code: `};` },
   ],
   [
     {
-      content: `// Copy the code below
+      code: `// Copy the code below
 
 export const Warning: Story = {
   args: {
@@ -82,9 +82,9 @@ export const Default: Story = {
     );
   },
   args: {
-    contents: newData,
+    data: newData,
     activeStep: 1,
-    width: "50%",
+    width: 480,
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
@@ -92,13 +92,13 @@ export const Default: Story = {
     const nextButton = canvas.getByText("Next");
 
     const firstElement = await canvas.findByText(
-      textContentMatcher(newData[0][0].content)
+      textContentMatcher(newData[0][0].code)
     );
     const secondElement = await canvas.findByText(
-      textContentMatcher(newData[1][0].content)
+      textContentMatcher(newData[1][0].code)
     );
     const thirdElement = await canvas.findByText(
-      textContentMatcher(newData[2][0].content)
+      textContentMatcher(newData[2][0].code)
     );
 
     await expect(

--- a/src/components/SyntaxHighlighter/SyntaxHighlighter.stories.tsx
+++ b/src/components/SyntaxHighlighter/SyntaxHighlighter.stories.tsx
@@ -16,7 +16,7 @@ export default meta;
 
 type Story = StoryObj<typeof SyntaxHighlighter>;
 
-const newData = [
+const data = [
   [
     {
       code: `// Button.stories.tsx`,
@@ -70,11 +70,17 @@ export const Default: Story = {
   render: (args) => {
     const [activeStep, setActiveStep] = React.useState(1);
 
+    console.log(activeStep);
+
     return (
       <div>
         <SyntaxHighlighter {...args} activeStep={activeStep} />
         <button onClick={() => setActiveStep(0)}>Reset</button>
-        <button onClick={() => setActiveStep((step) => step - 1)}>
+        <button
+          onClick={() =>
+            setActiveStep((step) => (activeStep > 0 ? step - 1 : 0))
+          }
+        >
           Previous
         </button>
         <button onClick={() => setActiveStep((step) => step + 1)}>Next</button>
@@ -82,7 +88,7 @@ export const Default: Story = {
     );
   },
   args: {
-    data: newData,
+    data: data,
     activeStep: 1,
     width: 480,
   },
@@ -92,13 +98,13 @@ export const Default: Story = {
     const nextButton = canvas.getByText("Next");
 
     const firstElement = await canvas.findByText(
-      textContentMatcher(newData[0][0].code)
+      textContentMatcher(data[0][0].code)
     );
     const secondElement = await canvas.findByText(
-      textContentMatcher(newData[1][0].code)
+      textContentMatcher(data[1][0].code)
     );
     const thirdElement = await canvas.findByText(
-      textContentMatcher(newData[2][0].code)
+      textContentMatcher(data[2][0].code)
     );
 
     await expect(

--- a/src/components/SyntaxHighlighter/SyntaxHighlighter.stories.tsx
+++ b/src/components/SyntaxHighlighter/SyntaxHighlighter.stories.tsx
@@ -70,8 +70,6 @@ export const Default: Story = {
   render: (args) => {
     const [activeStep, setActiveStep] = React.useState(1);
 
-    console.log(activeStep);
-
     return (
       <div>
         <SyntaxHighlighter {...args} activeStep={activeStep} />

--- a/src/components/SyntaxHighlighter/SyntaxHighlighter.styled.tsx
+++ b/src/components/SyntaxHighlighter/SyntaxHighlighter.styled.tsx
@@ -6,11 +6,11 @@ export const Code = styled(motion.div)`
   z-index: 2;
 `;
 
-export const Container = styled.div<{ width: string }>`
+export const Container = styled.div<{ width: number }>`
   position: relative;
   box-sizing: border-box;
   background: #171c23;
-  width: ${({ width }) => width};
+  width: ${({ width }) => width}px;
   height: 100%;
   overflow: hidden;
   padding-left: 15px;

--- a/src/components/SyntaxHighlighter/SyntaxHighlighter.tsx
+++ b/src/components/SyntaxHighlighter/SyntaxHighlighter.tsx
@@ -77,7 +77,7 @@ export const SyntaxHighlighter = ({
     });
 
     refs.forEach((ref) => {
-      resizeObserver.observe(ref.current!);
+      if (ref.current) resizeObserver.observe(ref.current!);
     });
 
     return () => {

--- a/src/components/SyntaxHighlighter/SyntaxHighlighter.tsx
+++ b/src/components/SyntaxHighlighter/SyntaxHighlighter.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useMemo } from "react";
+import React, {
+  createRef,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import { Backdrop, Code, Container } from "./SyntaxHighlighter.styled";
 import { Snippet } from "./Snippet/Snippet";
 
@@ -8,6 +14,13 @@ type SyntaxHighlighterProps = {
   width: number;
 };
 
+type StepsProps = {
+  yPos: number;
+  backdropHeight: number;
+  index: number;
+  open: boolean;
+};
+
 const OFFSET = 49;
 
 export const SyntaxHighlighter = ({
@@ -15,12 +28,10 @@ export const SyntaxHighlighter = ({
   data,
   width,
 }: SyntaxHighlighterProps) => {
-  const [steps, setSteps] = React.useState<
-    { yPos: number; height: number; index: number; open: boolean }[]
-  >([]);
+  const [steps, setSteps] = useState<StepsProps[]>([]);
 
   const refs = useMemo(
-    () => data.map(() => React.createRef<HTMLDivElement>()),
+    () => data.map(() => createRef<HTMLDivElement>()),
     [data]
   );
 
@@ -34,11 +45,11 @@ export const SyntaxHighlighter = ({
 
   const setNewSteps = useCallback(() => {
     const newSteps = data.flatMap((content, i) => {
-      const height = refs[i].current!.getBoundingClientRect().height;
+      const backdropHeight = refs[i].current!.getBoundingClientRect().height;
       const finalSteps = [
         {
           yPos: getYPos(i) + OFFSET - 7,
-          height,
+          backdropHeight,
           index: i,
           open: false,
         },
@@ -47,7 +58,7 @@ export const SyntaxHighlighter = ({
       if (content.length > 1) {
         finalSteps.push({
           yPos: getYPos(i) + OFFSET - 7,
-          height,
+          backdropHeight,
           index: i,
           open: true,
         });
@@ -95,7 +106,7 @@ export const SyntaxHighlighter = ({
         ))}
       </Code>
       <Backdrop
-        animate={{ height: steps[activeStep]?.height ?? 0 }}
+        animate={{ height: steps[activeStep]?.backdropHeight ?? 0 }}
         transition={{ ease: "easeInOut", duration: 0.6 }}
         style={{ top: OFFSET }}
         className="syntax-highlighter-backdrop"

--- a/src/components/SyntaxHighlighter/SyntaxHighlighter.tsx
+++ b/src/components/SyntaxHighlighter/SyntaxHighlighter.tsx
@@ -1,18 +1,18 @@
-import React, { useCallback, useEffect, useLayoutEffect, useMemo } from "react";
+import React, { useCallback, useEffect, useMemo } from "react";
 import { Backdrop, Code, Container } from "./SyntaxHighlighter.styled";
 import { Snippet } from "./Snippet/Snippet";
 
 type SyntaxHighlighterProps = {
-  contents: { content: string; toggle?: boolean }[][];
+  data: { code: string; toggle?: boolean }[][];
   activeStep: number;
-  width: string;
+  width: number;
 };
 
 const OFFSET = 49;
 
 export const SyntaxHighlighter = ({
   activeStep,
-  contents,
+  data,
   width,
 }: SyntaxHighlighterProps) => {
   const [steps, setSteps] = React.useState<
@@ -20,8 +20,8 @@ export const SyntaxHighlighter = ({
   >([]);
 
   const refs = useMemo(
-    () => contents.map(() => React.createRef<HTMLDivElement>()),
-    [contents]
+    () => data.map(() => React.createRef<HTMLDivElement>()),
+    [data]
   );
 
   const getYPos = (idx: number) => {
@@ -33,7 +33,7 @@ export const SyntaxHighlighter = ({
   };
 
   const setNewSteps = useCallback(() => {
-    const newSteps = contents.flatMap((content, i) => {
+    const newSteps = data.flatMap((content, i) => {
       const height = refs[i].current!.getBoundingClientRect().height;
       const finalSteps = [
         {
@@ -57,7 +57,7 @@ export const SyntaxHighlighter = ({
     });
 
     setSteps(newSteps);
-  }, [contents]);
+  }, [data]);
 
   useEffect(() => {
     // Call setNewSteps every time height of the refs elements changes
@@ -75,33 +75,31 @@ export const SyntaxHighlighter = ({
   }, []);
 
   return (
-    <>
-      <Container width={width}>
-        <Code
-          animate={{ y: steps[activeStep]?.yPos ?? 0 }}
-          transition={{ ease: "easeInOut", duration: 0.6 }}
-        >
-          {contents.map((content, idx: number) => (
-            <Snippet
-              key={idx}
-              ref={refs[idx]}
-              active={steps[activeStep]?.index === idx}
-              open={
-                steps[activeStep]?.index > idx
-                  ? true
-                  : steps[activeStep]?.open ?? false
-              }
-              contents={content}
-            />
-          ))}
-        </Code>
-        <Backdrop
-          animate={{ height: steps[activeStep]?.height ?? 0 }}
-          transition={{ ease: "easeInOut", duration: 0.6 }}
-          style={{ top: OFFSET }}
-          className="syntax-highlighter-backdrop"
-        />
-      </Container>
-    </>
+    <Container width={width}>
+      <Code
+        animate={{ y: steps[activeStep]?.yPos ?? 0 }}
+        transition={{ ease: "easeInOut", duration: 0.6 }}
+      >
+        {data.map((content, idx: number) => (
+          <Snippet
+            key={idx}
+            ref={refs[idx]}
+            active={steps[activeStep]?.index === idx}
+            open={
+              steps[activeStep]?.index > idx
+                ? true
+                : steps[activeStep]?.open ?? false
+            }
+            content={content}
+          />
+        ))}
+      </Code>
+      <Backdrop
+        animate={{ height: steps[activeStep]?.height ?? 0 }}
+        transition={{ ease: "easeInOut", duration: 0.6 }}
+        style={{ top: OFFSET }}
+        className="syntax-highlighter-backdrop"
+      />
+    </Container>
   );
 };

--- a/src/components/SyntaxHighlighter/SyntaxHighlighter.tsx
+++ b/src/components/SyntaxHighlighter/SyntaxHighlighter.tsx
@@ -1,7 +1,7 @@
 import React, {
   createRef,
   useCallback,
-  useEffect,
+  useLayoutEffect,
   useMemo,
   useState,
 } from "react";
@@ -70,14 +70,14 @@ export const SyntaxHighlighter = ({
     setSteps(newSteps);
   }, [data]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     // Call setNewSteps every time height of the refs elements changes
     const resizeObserver = new ResizeObserver(() => {
       setNewSteps();
     });
 
     refs.forEach((ref) => {
-      if (ref.current) resizeObserver.observe(ref.current!);
+      resizeObserver.observe(ref.current!);
     });
 
     return () => {

--- a/src/features/WriteStoriesModal/WriteStoriesModal.styled.tsx
+++ b/src/features/WriteStoriesModal/WriteStoriesModal.styled.tsx
@@ -1,4 +1,4 @@
-import { styled } from "@storybook/theming";
+import { keyframes, styled } from "@storybook/theming";
 
 export const ModalContent = styled.div`
   display: flex;
@@ -8,6 +8,7 @@ export const ModalContent = styled.div`
 `;
 
 export const Main = styled.div`
+  position: relative;
   flex: 1;
   display: flex;
   flex-direction: column;
@@ -45,7 +46,7 @@ export const Content = styled.div`
   flex-direction: column;
   align-items: flex-end;
   justify-content: space-between;
-  color: #454e54;
+  color: ${({ theme }) => theme.color.darker};
 
   h3 {
     font-size: 13px;
@@ -68,4 +69,81 @@ export const SpanHighlight = styled.span`
 export const Image = styled.img`
   max-width: 100%;
   margin-top: 1em;
+`;
+
+export const Background = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: -1;
+  overflow: hidden;
+`;
+
+export const circle1Anim = keyframes`
+  0% { transform: translate(0px, 0px) }
+  50% { transform: translate(120px, 0px) }
+  100% { transform: translate(0px, 0px) }
+`;
+
+export const Circle1 = styled.div`
+  position: absolute;
+  width: 350px;
+  height: 350px;
+  left: -160px;
+  top: -260px;
+  background: radial-gradient(
+    circle at center,
+    rgba(255, 119, 119, 1) 0%,
+    rgba(255, 119, 119, 0) 70%
+  );
+  animation: ${circle1Anim} 8s linear infinite;
+  animation-timing-function: ease-in-out;
+  z-index: 2;
+`;
+
+export const circle2Anim = keyframes`
+  0% { transform: translate(0px, 0px) }
+  33% { transform: translate(-64px, 0px) }
+  66% { transform: translate(120px, 0px) }
+  100% { transform: translate(0px, 0px) }
+`;
+
+export const Circle2 = styled.div`
+  position: absolute;
+  width: 350px;
+  height: 350px;
+  left: -54px;
+  top: -250px;
+  background: radial-gradient(
+    circle at center,
+    rgba(253, 255, 147, 1) 0%,
+    rgba(253, 255, 147, 0) 70%
+  );
+  animation: ${circle2Anim} 12s linear infinite;
+  animation-timing-function: ease-in-out;
+  z-index: 3;
+`;
+
+export const circle3Anim = keyframes`
+  0% { transform: translate(0px, 0px) }
+  50% { transform: translate(-120px, 0px) }
+  100% { transform: translate(0px, 0px) }
+`;
+
+export const Circle3 = styled.div`
+  position: absolute;
+  width: 350px;
+  height: 350px;
+  left: 150px;
+  top: -220px;
+  background: radial-gradient(
+    circle at center,
+    rgba(119, 255, 247, 0.8) 0%,
+    rgba(119, 255, 247, 0) 70%
+  );
+  animation: ${circle3Anim} 4s linear infinite;
+  animation-timing-function: ease-in-out;
+  z-index: 4;
 `;

--- a/src/features/WriteStoriesModal/WriteStoriesModal.styled.tsx
+++ b/src/features/WriteStoriesModal/WriteStoriesModal.styled.tsx
@@ -37,9 +37,9 @@ export const ModalTitle = styled.div`
   }
 `;
 
-export const Description = styled.div`
+export const Content = styled.div`
   font-size: 13px;
-  padding: 1em;
+  padding: 15px;
   flex: 1;
   display: flex;
   flex-direction: column;
@@ -53,11 +53,6 @@ export const Description = styled.div`
     padding: 0;
     margin: 0;
   }
-`;
-
-export const ContentWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
 `;
 
 export const SpanHighlight = styled.span`

--- a/src/features/WriteStoriesModal/WriteStoriesModal.styled.tsx
+++ b/src/features/WriteStoriesModal/WriteStoriesModal.styled.tsx
@@ -15,24 +15,25 @@ export const Main = styled.div`
 `;
 
 export const Header = styled.div`
+  box-sizing: border-box;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  color: ${({ theme }) => theme.color.darkest};
-  padding: 1em;
+  padding: 0 15px;
   border-bottom: 1px solid ${({ theme }) => theme.appBorderColor};
+  height: 40px;
+`;
 
-  h2 {
-    margin: 0;
-    padding: 0;
-    display: flex;
-    align-items: center;
-    font-size: 13px;
-    font-weight: bold;
-  }
+export const ModalTitle = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 13px;
+  font-weight: bold;
+  color: ${({ theme }) => theme.color.darkest};
 
-  svg {
-    margin-right: 0.5em;
+  span {
+    margin-top: 2px;
   }
 `;
 

--- a/src/features/WriteStoriesModal/WriteStoriesModal.styled.tsx
+++ b/src/features/WriteStoriesModal/WriteStoriesModal.styled.tsx
@@ -3,6 +3,7 @@ import { styled } from "@storybook/theming";
 export const ModalContent = styled.div`
   display: flex;
   flex-direction: row;
+  height: 100%;
   max-height: 85vh;
 `;
 

--- a/src/features/WriteStoriesModal/WriteStoriesModal.tsx
+++ b/src/features/WriteStoriesModal/WriteStoriesModal.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import React from "react";
 import { Button } from "../../components/Button/Button";
 
 import { Modal } from "../../components/Modal/Modal";
@@ -27,6 +27,9 @@ import dataTypescript from "./code/typescript";
 import dataTypescriptNextjs from "./code/nextjs-typescript";
 import { useGetProject } from "./hooks/useGetFrameworkName";
 import { API, AddonStore } from "@storybook/manager-api";
+
+// TODO: Add warning if backdropBoundary && !warningButtonStatus?.data is not true.
+// backdropBoundary && !warningButtonStatus?.data
 
 export function WriteStoriesModal({
   onFinish,
@@ -66,7 +69,7 @@ export function WriteStoriesModal({
     : dataTypescript;
 
   const copyWarningStory = () => {
-    const warningContent = data[4][0].content;
+    const warningContent = data[4][0].code;
     navigator.clipboard.writeText(
       warningContent.replace("// Copy the code below", "")
     );
@@ -82,15 +85,15 @@ export function WriteStoriesModal({
   };
 
   return (
-    <Modal width={738} height={445} defaultOpen>
+    <Modal width={740} height={430} defaultOpen>
       {({ Title, Description: DefaultDescription, Close }) => (
         <ModalContent>
           <div style={{ height: "445px", backgroundColor: "#171c23" }}>
             {data ? (
               <SyntaxHighlighter
                 activeStep={stepIndex[step] || 1}
-                contents={data}
-                width="445px"
+                data={data}
+                width={445}
               />
             ) : null}
             {backdropBoundary && !warningButtonStatus?.data && (

--- a/src/features/WriteStoriesModal/WriteStoriesModal.tsx
+++ b/src/features/WriteStoriesModal/WriteStoriesModal.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
 import { Button } from "../../components/Button/Button";
-
 import { Modal } from "../../components/Modal/Modal";
 import { Icons } from "@storybook/components";
 import useMeasure from "react-use-measure";
@@ -21,7 +20,6 @@ import { useGetBackdropBoundary } from "./hooks/useGetBackdropBoundary";
 import titleSidebarImg from "./assets/01-title-sidebar.png";
 import storyNameSidebarImg from "./assets/02-story-name-sidebar.png";
 import argsImg from "./assets/03-args.png";
-
 import dataJavascript from "./code/javascript";
 import dataTypescript from "./code/typescript";
 import dataTypescriptNextjs from "./code/nextjs-typescript";
@@ -88,35 +86,33 @@ export function WriteStoriesModal({
     <Modal width={740} height={430} defaultOpen>
       {({ Title, Description: DefaultDescription, Close }) => (
         <ModalContent>
-          <div style={{ height: "445px", backgroundColor: "#171c23" }}>
-            {data ? (
-              <SyntaxHighlighter
-                activeStep={stepIndex[step] || 1}
-                data={data}
-                width={445}
-              />
-            ) : null}
-            {backdropBoundary && !warningButtonStatus?.data && (
-              <Button
-                ref={clipboardButtonRef}
-                onClick={() => {
-                  copyWarningStory();
-                }}
-                style={{
-                  position: "absolute",
-                  top: backdropBoundary.top + backdropBoundary.height - 45,
-                  left:
-                    backdropBoundary.left +
-                    backdropBoundary.width -
-                    (clipboardButtonBounds.width ?? 0) -
-                    10,
-                  zIndex: 1000,
-                }}
-              >
-                {isWarningStoryCopied ? "Copied to clipboard" : "Copy code"}
-              </Button>
-            )}
-          </div>
+          {data ? (
+            <SyntaxHighlighter
+              activeStep={stepIndex[step] || 1}
+              data={data}
+              width={480}
+            />
+          ) : null}
+          {backdropBoundary && !warningButtonStatus?.data && (
+            <Button
+              ref={clipboardButtonRef}
+              onClick={() => {
+                copyWarningStory();
+              }}
+              style={{
+                position: "absolute",
+                top: backdropBoundary.top + backdropBoundary.height - 45,
+                left:
+                  backdropBoundary.left +
+                  backdropBoundary.width -
+                  (clipboardButtonBounds.width ?? 0) -
+                  10,
+                zIndex: 1000,
+              }}
+            >
+              {isWarningStoryCopied ? "Copied to clipboard" : "Copy code"}
+            </Button>
+          )}
           <Main>
             <Header>
               <Title>

--- a/src/features/WriteStoriesModal/WriteStoriesModal.tsx
+++ b/src/features/WriteStoriesModal/WriteStoriesModal.tsx
@@ -4,6 +4,10 @@ import { Modal } from "../../components/Modal/Modal";
 import { Icons } from "@storybook/components";
 import useMeasure from "react-use-measure";
 import {
+  Background,
+  Circle1,
+  Circle2,
+  Circle3,
   Content,
   Header,
   Image,
@@ -278,6 +282,11 @@ export function WriteStoriesModal({
                   ) : null)}
               </Content>
             </Description>
+            <Background>
+              <Circle1 />
+              <Circle2 />
+              <Circle3 />
+            </Background>
           </Main>
         </ModalContent>
       )}

--- a/src/features/WriteStoriesModal/WriteStoriesModal.tsx
+++ b/src/features/WriteStoriesModal/WriteStoriesModal.tsx
@@ -4,7 +4,7 @@ import { Modal } from "../../components/Modal/Modal";
 import { Icons } from "@storybook/components";
 import useMeasure from "react-use-measure";
 import {
-  Description,
+  Content,
   Header,
   Image,
   Main,
@@ -85,7 +85,7 @@ export function WriteStoriesModal({
 
   return (
     <Modal width={740} height={430} defaultOpen>
-      {({ Title, Description: DefaultDescription, Close }) => (
+      {({ Title, Description, Close }) => (
         <ModalContent>
           {data ? (
             <SyntaxHighlighter
@@ -126,8 +126,8 @@ export function WriteStoriesModal({
                 <Icons style={{ cursor: "pointer" }} icon="cross" width={13} />
               </Close>
             </Header>
-            <DefaultDescription asChild>
-              <Description>
+            <Description asChild>
+              <Content>
                 {step === "imports" && (
                   <>
                     <div>
@@ -276,8 +276,8 @@ export function WriteStoriesModal({
                       ) : null}
                     </>
                   ) : null)}
-              </Description>
-            </DefaultDescription>
+              </Content>
+            </Description>
           </Main>
         </ModalContent>
       )}

--- a/src/features/WriteStoriesModal/WriteStoriesModal.tsx
+++ b/src/features/WriteStoriesModal/WriteStoriesModal.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { Button } from "../../components/Button/Button";
 
 import { Modal } from "../../components/Modal/Modal";
@@ -40,11 +40,19 @@ export function WriteStoriesModal({
   api: API;
   addonsStore: AddonStore;
 }) {
-  const [step, setStep] = React.useState<
+  const [step, setStep] = useState<
     "imports" | "meta" | "story" | "args" | "customStory"
   >("imports");
 
-  const [isWarningStoryCopied, setWarningStoryCopied] = React.useState(false);
+  const stepIndex = {
+    imports: 1,
+    meta: 2,
+    story: 3,
+    args: 4,
+    customStory: 5,
+  };
+
+  const [isWarningStoryCopied, setWarningStoryCopied] = useState(false);
 
   const [clipboardButtonRef, clipboardButtonBounds] = useMeasure();
 
@@ -74,14 +82,6 @@ export function WriteStoriesModal({
       warningContent.replace("// Copy the code below", "")
     );
     setWarningStoryCopied(true);
-  };
-
-  const stepIndex = {
-    imports: 1,
-    meta: 2,
-    story: 3,
-    args: 4,
-    customStory: 5,
   };
 
   return (

--- a/src/features/WriteStoriesModal/WriteStoriesModal.tsx
+++ b/src/features/WriteStoriesModal/WriteStoriesModal.tsx
@@ -9,6 +9,7 @@ import {
   Image,
   Main,
   ModalContent,
+  ModalTitle,
   SpanHighlight,
 } from "./WriteStoriesModal.styled";
 import { SyntaxHighlighter } from "../../components/SyntaxHighlighter/SyntaxHighlighter";
@@ -115,12 +116,14 @@ export function WriteStoriesModal({
           )}
           <Main>
             <Header>
-              <Title>
-                <Icons icon="bookmarkhollow" />{" "}
-                <span>How to write a story</span>
+              <Title asChild>
+                <ModalTitle>
+                  <Icons icon="bookmarkhollow" width={13} />
+                  <span>How to write a story</span>
+                </ModalTitle>
               </Title>
               <Close asChild>
-                <Icons style={{ cursor: "pointer" }} icon="closeAlt" />
+                <Icons style={{ cursor: "pointer" }} icon="cross" width={13} />
               </Close>
             </Header>
             <DefaultDescription asChild>

--- a/src/features/WriteStoriesModal/code/javascript.tsx
+++ b/src/features/WriteStoriesModal/code/javascript.tsx
@@ -1,17 +1,17 @@
 export default [
   [
     {
-      content: `// Button.stories.jsx`,
+      code: `// Button.stories.jsx`,
     },
   ],
   [
     {
-      content: `import { Button } from './Button';`,
+      code: `import { Button } from './Button';`,
     },
   ],
   [
     {
-      content: `const meta = {
+      code: `const meta = {
       title: 'Example/Button',
       component: Button,
       // ...
@@ -21,20 +21,20 @@ export default [
     },
   ],
   [
-    { content: `export const Primary = {` },
+    { code: `export const Primary = {` },
     {
-      content: `args: {
+      code: `args: {
         primary: true,
         label: 'Click',
         background: 'red'
       }`,
       toggle: true,
     },
-    { content: `};` },
+    { code: `};` },
   ],
   [
     {
-      content: `// Copy the code below
+      code: `// Copy the code below
 export const Warning = {
   args: {
     primary: true,

--- a/src/features/WriteStoriesModal/code/nextjs-typescript.tsx
+++ b/src/features/WriteStoriesModal/code/nextjs-typescript.tsx
@@ -1,19 +1,19 @@
 export default [
   [
     {
-      content: `// Button.stories.tsx`,
+      code: `// Button.stories.tsx`,
     },
   ],
   [
     {
-      content: `import type { Meta, StoryObj } from '@storybook/nextjs';
+      code: `import type { Meta, StoryObj } from '@storybook/nextjs';
     
     import { Button } from './Button';`,
     },
   ],
   [
     {
-      content: `const meta: Meta<typeof Button> = {
+      code: `const meta: Meta<typeof Button> = {
       title: 'Example/Button',
       component: Button,
       // ...
@@ -23,20 +23,20 @@ export default [
     },
   ],
   [
-    { content: `export const Primary: Story = {` },
+    { code: `export const Primary: Story = {` },
     {
-      content: `args: {
+      code: `args: {
         primary: true,
         label: 'Click',
         background: 'red'
       }`,
       toggle: true,
     },
-    { content: `};` },
+    { code: `};` },
   ],
   [
     {
-      content: `// Copy the code below
+      code: `// Copy the code below
 export const Warning: Story = {
   args: {
     primary: true,

--- a/src/features/WriteStoriesModal/code/typescript.tsx
+++ b/src/features/WriteStoriesModal/code/typescript.tsx
@@ -1,19 +1,19 @@
 export default [
   [
     {
-      content: `// Button.stories.tsx`,
+      code: `// Button.stories.tsx`,
     },
   ],
   [
     {
-      content: `import type { Meta, StoryObj } from '@storybook/react';
+      code: `import type { Meta, StoryObj } from '@storybook/react';
     
     import { Button } from './Button';`,
     },
   ],
   [
     {
-      content: `const meta: Meta<typeof Button> = {
+      code: `const meta: Meta<typeof Button> = {
       title: 'Example/Button',
       component: Button,
       // ...
@@ -23,20 +23,20 @@ export default [
     },
   ],
   [
-    { content: `export const Primary: Story = {` },
+    { code: `export const Primary: Story = {` },
     {
-      content: `args: {
+      code: `args: {
         primary: true,
         label: 'Click',
         background: 'red'
       }`,
       toggle: true,
     },
-    { content: `};` },
+    { code: `};` },
   ],
   [
     {
-      content: `// Copy the code below
+      code: `// Copy the code below
 export const Warning: Story = {
   args: {
     primary: true,


### PR DESCRIPTION
In this PR, I improved the write a story part:
- Fixed the blurred text
- Fixed the horizontal scroll
- Added colours on the background on the right panel
- Adjusted paddings and positioning of the content

Closes https://github.com/storybookjs/addon-onboarding/issues/25
Closes https://github.com/storybookjs/addon-onboarding/issues/32

<img width="830" alt="CleanShot 2023-06-07 at 12 15 39@2x" src="https://github.com/storybookjs/addon-onboarding/assets/1540635/952e66e8-81d1-47fc-b6aa-5eb86c2115de">

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.19--canary.38.3c859a1.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/addon-onboarding@0.0.19--canary.38.3c859a1.0
  # or 
  yarn add @storybook/addon-onboarding@0.0.19--canary.38.3c859a1.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
