### PR TITLE
fix tooltip in dark mode

### DIFF
--- a/src/features/GuidedTour/GuidedTour.tsx
+++ b/src/features/GuidedTour/GuidedTour.tsx
@@ -137,7 +137,9 @@ export function GuidedTour({
             paddingLeft: 8,
             paddingTop: 8,
             filter:
-              "drop-shadow(0px 5px 5px rgba(0,0,0,0.05)) drop-shadow(0 1px 3px rgba(0,0,0,0.1))",
+              theme.base === 'light' 
+                ? "drop-shadow(0px 5px 5px rgba(0,0,0,0.05)) drop-shadow(0 1px 3px rgba(0,0,0,0.1))" 
+                : 'drop-shadow(white 0px 0px 0.5px) drop-shadow(white 0px 0px 0.5px)',
           },
         },
       }}
@@ -152,7 +154,7 @@ export function GuidedTour({
         options: {
           zIndex: 10000,
           primaryColor: theme.color.secondary,
-          arrowColor: theme.background.content,
+          arrowColor: theme.background.app,
         },
       }}
     />

--- a/src/features/GuidedTour/Tooltip.tsx
+++ b/src/features/GuidedTour/Tooltip.tsx
@@ -4,7 +4,7 @@ import { TooltipRenderProps } from "react-joyride";
 import { Button } from "../../components/Button/Button";
 
 const TooltipBody = styled.div`
-  background:  ${({ theme }) => theme.background.content};
+  background:  ${({ theme }) => theme.background.app};
   width: 260px;
   padding: 15px;
   border-radius: 5px;


### PR DESCRIPTION
<img width="1438" alt="image" src="https://github.com/storybookjs/addon-onboarding/assets/1671563/0035dcbe-cb62-4497-9a6e-a7a14aa67660">
<img width="757" alt="image" src="https://github.com/storybookjs/addon-onboarding/assets/1671563/a467e944-260e-4f3c-acb0-85b91ac94d2f">

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.36-canary.59.a5dbb09.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/addon-onboarding@0.0.36-canary.59.a5dbb09.0
  # or 
  yarn add @storybook/addon-onboarding@0.0.36-canary.59.a5dbb09.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
