### PR TITLE
Pass addon version in telemetry event

### DIFF
--- a/src/preset.ts
+++ b/src/preset.ts
@@ -19,11 +19,16 @@ export const experimental_serverChannel = async (
   );
 
   if (!disableTelemetry) {
+    const { version: addonVersion } = require("../package.json");
+
     channel.on(
       STORYBOOK_ADDON_ONBOARDING_CHANNEL,
       ({ type, ...event }: Event) => {
         if (type === "telemetry") {
-          telemetry("addon-onboarding" as any, event);
+          telemetry("addon-onboarding" as any, {
+            ...event,
+            addonVersion,
+          });
         }
       }
     );


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.38-canary.62.6768a55.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/addon-onboarding@0.0.38-canary.62.6768a55.0
  # or 
  yarn add @storybook/addon-onboarding@0.0.38-canary.62.6768a55.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
