### PR TITLE
Fix package.json version extraction

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,10 +40,12 @@ export default function App({ api }: { api: API }) {
   }, []);
 
   useEffect(() => {
-    api.emit(STORYBOOK_ADDON_ONBOARDING_CHANNEL, {
-      step,
-      type: "telemetry",
-    });
+    if (step !== '1:Welcome') {
+      api.emit(STORYBOOK_ADDON_ONBOARDING_CHANNEL, {
+        step,
+        type: "telemetry",
+      });
+    }
   }, [api, step]);
 
   useEffect(() => {

--- a/src/components/SyntaxHighlighter/SyntaxHighlighter.stories.tsx
+++ b/src/components/SyntaxHighlighter/SyntaxHighlighter.stories.tsx
@@ -91,7 +91,7 @@ export const Default: Story = {
     const canvas = within(canvasElement);
     const nextButton = canvas.getByText("Next");
     const firstElement = await canvas.findByText(
-      textContentMatcher(data[0][0].code)
+      textContentMatcher(data[0][0].code), undefined, { timeout: 3000 }
     );
     await expect(
       firstElement.closest('[aria-hidden="false"]')

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -2,6 +2,7 @@ import { CoreConfig, Options } from "@storybook/types";
 import type { Channel } from "@storybook/channels";
 import { STORYBOOK_ADDON_ONBOARDING_CHANNEL } from "./constants";
 import { telemetry } from "@storybook/telemetry";
+import fs from "fs";
 
 type Event = {
   type: "telemetry";
@@ -19,9 +20,13 @@ export const experimental_serverChannel = async (
   );
 
   if (!disableTelemetry) {
-    // To prevent prebundling a variable is used to require the package.json
-    const packageJsonPath = "../package.json";
-    const { version: addonVersion } = require(packageJsonPath);
+    const packageJsonPath = require.resolve(
+      "@storybook/addon-onboarding/package.json"
+    );
+
+    const { version: addonVersion } = JSON.parse(
+      fs.readFileSync(packageJsonPath, { encoding: "utf-8" })
+    );
 
     channel.on(
       STORYBOOK_ADDON_ONBOARDING_CHANNEL,

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -19,7 +19,9 @@ export const experimental_serverChannel = async (
   );
 
   if (!disableTelemetry) {
-    const { version: addonVersion } = require("../package.json");
+    // To prevent prebundling a variable is used to require the package.json
+    const packageJsonPath = "../package.json";
+    const { version: addonVersion } = require(packageJsonPath);
 
     channel.on(
       STORYBOOK_ADDON_ONBOARDING_CHANNEL,


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.2-canary.72.f943172.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/addon-onboarding@1.0.2-canary.72.f943172.0
  # or 
  yarn add @storybook/addon-onboarding@1.0.2-canary.72.f943172.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
