### PR TITLE
Fix Yarn remove command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This addon serves to provide you a guided experience on the basics of Storybook.
 yarn:
 
 ```zsh
-yarn remove -D @storybook/addon-onboarding
+yarn remove @storybook/addon-onboarding
 ```
 
 npm:


### PR DESCRIPTION
Yarn does not support `-D` option when removing a package:

```Unknown Syntax Error: Unsupported option name ("-D").```