### PR TITLE
Make selectors Storybook 8 compatible

### DIFF
--- a/src/features/GuidedTour/GuidedTour.tsx
+++ b/src/features/GuidedTour/GuidedTour.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import Joyride, { CallBackProps, STATUS } from "react-joyride";
 import { API } from "@storybook/manager-api";
 import { UPDATE_STORY_ARGS } from "@storybook/core-events";
@@ -33,6 +33,11 @@ export function GuidedTour({
       setStepIndex(3);
     });
   }, []);
+
+
+  const storyPlaygroundElement = useMemo(() => {
+    return (document.querySelector("#root div[role=main]") || document.querySelector("#storybook-panel-root")) as HTMLElement
+  }, [])
 
   const steps: GuidedTourStep[] = isFinalStep
     ? [
@@ -100,7 +105,7 @@ export function GuidedTour({
         },
       },
       {
-        target: "#root div[role=main]",
+        target: storyPlaygroundElement,
         title: "Interactive story playground",
         content: (
           <>


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/25288

This PR makes it so that the selectors used for the "interactive playground" step are compatible with both SB 7 and 8. Because react joyride can't highlight two elements as if they're one, there will be visual differences in Storybook 8, given that what used to be a single element now is a combination of two.

Storybook 7 
![image](https://github.com/storybookjs/addon-onboarding/assets/1671563/1319907b-f7c6-4e34-b970-be18ca6c1e96)

Storybook 8
![image](https://github.com/storybookjs/addon-onboarding/assets/1671563/1ea5a540-d5fb-4875-ab9b-cca076612526)
