### PR TITLE
Fix z-index bug by adding a wrapper

### DIFF
--- a/src/features/WelcomeModal/WelcomeModal.tsx
+++ b/src/features/WelcomeModal/WelcomeModal.tsx
@@ -26,31 +26,33 @@ export const WelcomeModal: FC<WelcomeModalProps> = ({
   skipOnboarding,
 }) => {
   return (
-    <Modal width={540} height={430} defaultOpen>
-      {({ Close }) => (
-        <ModalContentWrapper data-chromatic="ignore">
-          <TopContent>
-            <StorybookLogo />
-            <Title>Welcome to Storybook</Title>
-            <Description>
-              Storybook helps you develop UI components faster. Learn the basics in a
-              few simple steps.
-            </Description>
-            <Button style={{ marginTop: 4 }} onClick={onProceed}>
-              Start your 3 minute tour
-            </Button>
-          </TopContent>
-          <SkipButton onClick={skipOnboarding}>
-            Skip tour
-            <StyledIcon icon="arrowright" />
-          </SkipButton>
-          <Background>
-            <Circle1 />
-            <Circle2 />
-            <Circle3 />
-          </Background>
-        </ModalContentWrapper>
-      )}
-    </Modal>
+    <div style={{ zIndex: 10 }}>
+      <Modal width={540} height={430} defaultOpen>
+        {({ Close }) => (
+          <ModalContentWrapper data-chromatic="ignore">
+            <TopContent>
+              <StorybookLogo />
+              <Title>Welcome to Storybook</Title>
+              <Description>
+                Storybook helps you develop UI components faster. Learn the
+                basics in a few simple steps.
+              </Description>
+              <Button style={{ marginTop: 4 }} onClick={onProceed}>
+                Start your 3 minute tour
+              </Button>
+            </TopContent>
+            <SkipButton onClick={skipOnboarding}>
+              Skip tour
+              <StyledIcon icon="arrowright" />
+            </SkipButton>
+            <Background>
+              <Circle1 />
+              <Circle2 />
+              <Circle3 />
+            </Background>
+          </ModalContentWrapper>
+        )}
+      </Modal>
+    </div>
   );
 };


### PR DESCRIPTION
Closes: https://github.com/storybookjs/storybook/issues/25288

Tested locally using the canary:
![Screenshot 2024-01-23 at 14 18 45](https://github.com/storybookjs/addon-onboarding/assets/3070389/4efd6f37-41b0-425e-81d9-3180c3166c9d)
![Screenshot 2024-01-23 at 14 19 39](https://github.com/storybookjs/addon-onboarding/assets/3070389/f44e9a71-2d46-46d2-b114-081f61fb52d7)


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.11-canary.82.870db45.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/addon-onboarding@1.0.11-canary.82.870db45.0
  # or 
  yarn add @storybook/addon-onboarding@1.0.11-canary.82.870db45.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
